### PR TITLE
Fix the build with GCC 4.9 & UNIX.

### DIFF
--- a/include/guicore.h
+++ b/include/guicore.h
@@ -29,7 +29,11 @@ You must read and accept the license prior to use.
 
 extern unsigned char GUI_ENABLED;
 
-#if (defined(__cplusplus)||defined(c_plusplus))
+
+#endif /* !defined(SNEeSe_guicore_h) */
+
+#if (defined(__cplusplus)||defined(c_plusplus)) && !defined(SNEeSe_guicore_cpp_h)
+#define SNEeSe_guicore_cpp_h
 
 /* ------------------------- DIRECTORY STUFF ------------------------- */
 
@@ -273,6 +277,4 @@ BITMAP *SetGUIScreen(int ScreenMode, int windowed);
 void gui_wait_for_input();
 
 
-#endif /* defined(__cplusplus)||defined(c_plusplus) */
-
-#endif /* !defined(SNEeSe_guicore_h) */
+#endif /* defined(__cplusplus)||defined(c_plusplus) && !defined(SNEeSe_guicore_cpp_h) */

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ PLATFORM := dos
 # How to call the tools we need to use
 
 NASM   := nasm -w+orphan-labels -w+macro-params -O20 -DC_LABELS_PREFIX=_
-GCC    := gcc -Werror -Wall
+GCC    := gcc -Wall
 RM     := rm -f
 MD     := mkdir
 

--- a/makefile.all
+++ b/makefile.all
@@ -31,7 +31,7 @@ DEBUG := 0
 endif
 
 ifndef SAVE_ASM_OUTPUT
-SAVE_ASM_OUTPUT := 1
+SAVE_ASM_OUTPUT := 0
 endif
 
 
@@ -70,7 +70,7 @@ EXE    := sneese$(SUFFIX)$(EXE_EXT)
 
 endif
 
-OFLAGS = -march=pentium -mtune=pentiumpro -O3 -ffast-math $(PFLAGS)
+OFLAGS = -O2 -ffast-math $(PFLAGS)
 endif
 
 
@@ -86,7 +86,7 @@ endif
 RELEASE ?= 0
 
 
-DFLAGS = -DDEBUG
+DFLAGS += -DDEBUG
 
 ifneq ($(RELEASE),0)
 DFLAGS += -DRELEASE_BUILD
@@ -154,13 +154,13 @@ $(OBJ)/%.s: $(SRC)/%.c
 	$(GCC) -S $(CFLAGS) $(DFLAGS) -o $@ $<
 
 $(OBJ)/%.s: $(SRC)/%.cpp
-	$(GCC) -S $(CPPFLAGS) $(DFLAGS) -o $@ $<
+	$(GXX) -S $(CPPFLAGS) $(DFLAGS) -o $@ $<
 else
 $(OBJ)/%.o: $(SRC)/%.c
 	$(GCC) -c $(CFLAGS) $(DFLAGS) -o $@ $<
 
 $(OBJ)/%.o: $(SRC)/%.cpp
-	$(GCC) -c $(CPPFLAGS) $(DFLAGS) -o $@ $<
+	$(GXX) -c $(CPPFLAGS) $(DFLAGS) -o $@ $<
 endif
 
 
@@ -186,14 +186,13 @@ $(OBJ)/ppu/ppu.$(ASM_OBJ_EXT): $(SRC)/ppu/ppu.asm $(OBJFIX) \
  ppu/screen.inc ppu/tiles.inc cpu/cpumem.inc cycles.inc cpu/regs.inc)
 $(OBJ)/apu/apuskip.$(ASM_OBJ_EXT): $(SRC)/apu/apuskip.asm $(OBJFIX) \
  $(addprefix $(INCLUDE)/, misc.inc ppu/ppu.inc)
-$(OBJ)/clear.$(ASM_OBJ_EXT): $(SRC)/clear.asm $(INCLUDE)/misc.inc $(OBJFIX) 
+$(OBJ)/clear.$(ASM_OBJ_EXT): $(SRC)/clear.asm $(INCLUDE)/misc.inc $(OBJFIX)
 $(OBJ)/ppu/screen.$(ASM_OBJ_EXT): $(SRC)/ppu/screen.asm $(OBJFIX) \
  $(addprefix $(INCLUDE)/, ppu/sprites.inc ppu/ppu.inc ppu/tiles.inc \
  ppu/screen.inc misc.inc clear.inc)
 
 $(OBJ)/ppu/windows.$(OBJBASE): $(SRC)/ppu/windows.c \
  $(addprefix $(INCLUDE)/, misc.h snes.h)
-	$(GCC) -S $(CFLAGS) $(DFLAGS) -Wno-array-bounds -o $@ $<
 
 $(OBJ)/ppu/tiles.$(ASM_OBJ_EXT): $(SRC)/ppu/tiles.asm $(OBJFIX) \
  $(addprefix $(INCLUDE)/, misc.inc ppu/ppu.inc ppu/tiles.inc ppu/screen.inc)
@@ -206,7 +205,6 @@ $(OBJ)/ppu/pass1.$(OBJBASE): $(SRC)/ppu/pass1.c \
  $(addprefix $(INCLUDE)/, helper.h allegro/wrapaleg.h platform.h misc.h snes.h \
  ppu/plotbase.h ppu/obj.h ppu/bgn.h ppu/bgm.h ppu/bgo.h ppu/bgom.h \
  ppu/pln.h ppu/plm.h ppu/plo.h ppu/plom.h ppu/dispatch.h ppu/mode7.h)
-	$(GCC) -S $(CFLAGS) $(DFLAGS) -Wno-unused-but-set-variable -o $@ $<
 
 $(OBJ)/ppu/pass2.$(OBJBASE): $(SRC)/ppu/pass2.c \
  $(addprefix $(INCLUDE)/, helper.h platform.h misc.h snes.h allegro/wrapaleg.h)
@@ -222,7 +220,6 @@ $(OBJ)/emugui.$(OBJBASE): $(SRC)/emugui.cpp \
  $(addprefix $(INCLUDE)/, guicore.h platform.h types.h font.h misc.h \
  helper.h input.h cpu/cpu.h apu/spc.h apu/sound.h romload.h debug.h snes.h \
  allegro/wrapaleg.h)
-	$(GCC) -S $(CFLAGS) $(DFLAGS) -Wno-unused-but-set-variable -o $@ $<
 $(OBJ)/romload.$(OBJBASE): $(SRC)/romload.cpp \
  $(addprefix $(INCLUDE)/, romload.h helper.h misc.h cpu/cpu.h apu/spc.h \
  cpu/mem.h snes.h allegro/wrapaleg.h patch.h platform.h multiio.h unzip.h) \
@@ -250,8 +247,6 @@ $(OBJ)/apu/spc700.$(OBJBASE): $(SRC)/apu/spc700.c $(OBJFIX) \
 $(OBJ)/apu/sound.$(OBJBASE): $(SRC)/apu/sound.c \
  $(addprefix $(INCLUDE)/, helper.h platform.h snes.h apu/sound.h \
  apu/sounddef.h apu/spc.h misc.h allegro/wrapaleg.h)
-	$(GCC) -S $(CFLAGS) $(DFLAGS) -Wno-unused-but-set-variable -o $@ $<
-
 $(OBJ)/map.$(OBJBASE): $(SRC)/map.c \
  $(addprefix $(INCLUDE)/, map.h misc.h)
 $(OBJ)/multiio.$(OBJBASE): $(SRC)/multiio.c \

--- a/makefile.beos
+++ b/makefile.beos
@@ -47,7 +47,7 @@ ALLEG  := `allegro-config --shared`
 
 SUFFIX :=
 AFLAGS := -f elf
-GXX    := g++
+GXX    := g++ -m32 -Wall
 PLATFORMOBJS := $(addprefix allegro/, platform.o)
 PLATFORMRULES = rulesalg.inc
 

--- a/makefile.unix
+++ b/makefile.unix
@@ -28,8 +28,9 @@ PLATFORM := unix
 
 # How to call the tools we need to use
 
-NASM   := nasm -w+orphan-labels -w+macro-params -O20 -DUNIX
-GCC    := gcc -Werror -Wall -DUNIX
+DFLAGS += -DUNIX
+NASM   := nasm -w+orphan-labels -w+macro-params -O20
+GCC    := gcc -m32 -Wall -Wno-unused-but-set-variable
 # GCC of DJGPP and Cygwin defines unix, __unix__ and __unix.
 RM     := rm -f
 MD     := mkdir -p
@@ -48,19 +49,13 @@ ALLEG  := `allegro-config --shared`
 
 SUFFIX :=
 AFLAGS := -f elf
-GXX    := g++
+GXX    := g++ -m32 -Wall -Wno-unused-but-set-variable
 PLATFORMOBJS := $(addprefix allegro/, platform.o)
 PLATFORMRULES = rulesalg.inc
 
 ZLIB   := 1 # comment this line to disable ZLIB support
 ifdef ZLIB
-# TODO: Fix the following problem. When dynamically linking to zlib I get the
-# error: "undefined reference to gzgets". This is strange, because I don't get
-# an error message for the other zlib functions. Even stranger, "ldd sneese"
-# doesn't show a reference to libz.so. For now the problem is "fixed" by
-# statically linking to zlib.
-#MIOFLAGS := -lz
-MIOFLAGS := /usr/lib/libz.a
+MIOFLAGS := -lz
 endif
 
 

--- a/makefile.win
+++ b/makefile.win
@@ -29,7 +29,7 @@ PLATFORM := win32
 # How to call the tools we need to use
 
 NASM   := nasm -w+orphan-labels -w+macro-params -O20 -DC_LABELS_PREFIX=_
-GCC    := gcc -Werror -Wall
+GCC    := gcc -Werror -Wall -Wno-unused-but-set-variable
 RM     := rm -f
 MD     := mkdir
 
@@ -47,7 +47,7 @@ ALLEG  := -lalleg44
 
 SUFFIX := w
 AFLAGS := -f win32
-GXX    := g++
+GXX    := g++ -m32 -Wall -Wno-unused-but-set-variable
 PLATFORMOBJS := $(addprefix allegro/, platform.o)
 PLATFORMRULES = rulesalg.inc
 

--- a/src/romload.cpp
+++ b/src/romload.cpp
@@ -351,12 +351,12 @@ int Allocate_ROM(bool resize)
  {
   return new_alloc_size;
  }
- 
 
- unsigned rom_address_temp;
+
+ intptr_t rom_address_temp;
 
  // Force 4k alignment/8k misalignment
- rom_address_temp = ((unsigned)
+ rom_address_temp = ((intptr_t)
    (AllocROMAddress + ((4 << 10) - 1)) & ~((4 << 10) - 1));
  if (!(rom_address_temp & (4 << 10))) rom_address_temp += (4 << 10);
 
@@ -618,7 +618,7 @@ extern "C" void reset_bus_timings(void)
  set_upper_rom_speed(0);
 
  /* access times in master cycles for for non-ROM areas */
- 
+
  /* 8 - RAM, 00-3F/80-BF:6000-7FFF */
  for (bank = 0; bank < 0x40; bank++)
  {
@@ -690,10 +690,10 @@ int Allocate_SRAM()
   }
  }
 
- unsigned sram_address_temp;
+ intptr_t sram_address_temp;
 
  // Force 4k alignment/8k misalignment
- sram_address_temp = ((unsigned)
+ sram_address_temp = ((intptr_t)
    (AllocSRAMAddress + ((4 << 10) - 1)) & ~((4 << 10) - 1));
  if (!(sram_address_temp & (4 << 10))) sram_address_temp += (4 << 10);
 
@@ -904,18 +904,18 @@ void Copy_32k(const unsigned char *buffer, size_t len)
 {
   const unsigned char *end = buffer + len;
   for (int cnt = 0; cnt < rmd_64k.bank_count; cnt++) // Read first half
-  { 
+  {
     memcpy(RomAddress + cnt * (64 << 10) + (32 << 10), buffer, (32 << 10));
     buffer += (32 << 10);
     if (buffer > end) break;
   }
- 
+
   for (int cnt = 0; cnt < rmd_64k.bank_count; cnt++) // Read second half
-  { 
+  {
     memcpy(RomAddress + cnt * (64 << 10), buffer, (32 << 10));
     buffer += (32 << 10);
     if (buffer > end) break;
-  } 
+  }
 }
 
 void Copy_64k(const unsigned char *buffer, size_t len)
@@ -924,7 +924,7 @@ void Copy_64k(const unsigned char *buffer, size_t len)
   for (int cnt = 0; cnt < rmd_64k.bank_count; cnt++) // Read in ROM
   {
     memcpy(RomAddress + cnt * (64 << 10), buffer, (64 << 10));
-    buffer += (64 << 10);    
+    buffer += (64 << 10);
     if (buffer > end) break;
   }
 }
@@ -933,7 +933,7 @@ void Setup_bank_count(const unsigned int size)
 {
   rmd_64k.bank_count = ((size + (64 << 10) - 1) / (64 << 10));
   rmd_32k.bank_count = ((size + (32 << 10) - 1) / (32 << 10));
-    
+
   // Maximum 64Mbit ROM size for LoROM
   if (rmd_64k.bank_count > ROM_SIZE_MAX / (64 << 10))
   {
@@ -955,15 +955,15 @@ unsigned check_for_header(MULTIIO_FILE_PTR fp, int filesize)
  // If ROM filesize is even multiple of 1k, +512, assume header
  if ((((filesize % 1024) == 0) || (ROM_force_header == Off)) &&
   (ROM_force_header != On))
- { 
+ {
   ROM_start = 0;
   ROM_has_header = Off;
- } 
+ }
  else if (((filesize % 1024) == ROM_Header_Size) || (ROM_force_header == On))
  {
   ROM_start = ROM_Header_Size;
   ROM_has_header = On;
- } 
+ }
  else { // Basic header detection failure
 /* Gridle 04/03/1998 (dmy)
 
@@ -1093,7 +1093,7 @@ void patch_rom(const char *Filename)
         *(strrchr(ips_file, '.')) = 0;
         strcat(ips_file, ".IPS");
         patchfile = ips_file;
-        PatchUsingIPS();       
+        PatchUsingIPS();
       }
 #endif
     }
@@ -1105,19 +1105,19 @@ void patch_rom(const char *Filename)
 
       if (CreateSaveFilename(ips_filename, ROM_filename, ".ips")) return;
       patchfile = ips_filename;
-      PatchUsingIPS();       
+      PatchUsingIPS();
 
 #ifdef FILE_CASE_SENSITIVE
       if (!IPSPatched)
       {
         if (CreateSaveFilename(ips_filename, ROM_filename, ".IPS")) return;
         patchfile = ips_filename;
-        PatchUsingIPS();       
+        PatchUsingIPS();
       }
 #endif
     }
 
-  } 
+  }
 }
 
 bool PatchROMAddress(const unsigned address, const unsigned char byte)
@@ -1182,7 +1182,7 @@ static bool open_rom_jma(const char *filename)
     unsigned char *ROM_buffer = buffer;
 
     JMAFile.extract_file(our_file_name, buffer);
-    
+
     if ((((our_file_size % 1024) == 0) || (ROM_force_header == Off)) &&
      (ROM_force_header != On))
     {
@@ -1201,15 +1201,15 @@ static bool open_rom_jma(const char *filename)
       printf("Header detected and ignored.\n");
     }
     else
-    { 
+    {
       printf("No header detected.\n");
     }
-    
+
     memcpy(&RomInfoLo, ROM_buffer+0x7FC0, sizeof(SNESRomInfoStruct));
     memcpy(&RomInfoHi, ROM_buffer+0xFFC0, sizeof(SNESRomInfoStruct));
-  
+
     HiLo_Detect();
-  
+
     Setup_bank_count(our_file_size);
 
     if (Allocate_ROM())   // Dynamic allocation of ROM
@@ -1217,7 +1217,7 @@ static bool open_rom_jma(const char *filename)
       free(buffer);
       return FALSE;        // return false if no memory left
     }
-  
+
     setup_rom_mirroring(&rmd_32k);
     setup_rom_mirroring(&rmd_64k);
 
@@ -1278,7 +1278,7 @@ static bool open_rom_jma(const char *filename)
 static bool open_rom_normal(const char *Filename)
 {
  if (!strcasecmp(fn_ext, ".jma")) return open_rom_jma(Filename);
- 
+
  MULTIIO_FILE_PTR infile = fopen2(Filename, "rb");
  if (!infile.mvPtr) return FALSE; // File aint there m8
 
@@ -1299,7 +1299,7 @@ static bool open_rom_normal(const char *Filename)
  fread2(&RomInfoHi, sizeof(SNESRomInfoStruct), 1, infile);
 
  HiLo_Detect();
- 
+
  Setup_bank_count(infilesize - ROM_start);
 
  if (Allocate_ROM())   // Dynamic allocation of ROM


### PR DESCRIPTION
- Force usage of -m32, as the assembly isn't 64-bit-safe.
- Correctly call g++ not gcc so we don't get typeinfo errors
- Fix Zlib linkage and remove old comment.

The only other change in here was to change the `unsigned` (int32) to an `intptr_t` for 64-bit safety, but that's kinda pointless since the assembly isn't 64-bit-safe. At this point there's probably no reason to keep it assembly, is there? C compilers optimize well enough at this point, and computers are fast enough anyway.
